### PR TITLE
Avoid using “prepare” hook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "node": ">= 7.6.0"
   },
   "scripts": {
-    "prepare": "node scripts/download-opencc-database.js"
+    "prep": "node scripts/download-opencc-database.js && npm test",
+    "test": "npm run prep && mocha"
   },
   "files": [
     "dist/*",


### PR DESCRIPTION
- The **prepare** hook runs every time the package is being installed. We do not want the library's unit tests to run when installing the library.